### PR TITLE
feat: implement custom REST API login flow replacing default Spring Security

### DIFF
--- a/backend/src/main/java/com/yurakim/readingtrace/shared/config/AuthenticationProviderImpl.java
+++ b/backend/src/main/java/com/yurakim/readingtrace/shared/config/AuthenticationProviderImpl.java
@@ -1,0 +1,38 @@
+package com.yurakim.readingtrace.shared.config;
+
+import lombok.AllArgsConstructor;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@AllArgsConstructor
+@Component
+public class AuthenticationProviderImpl implements AuthenticationProvider {
+
+    private final UserDetailsService userDetailsService;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        String username = authentication.getName();
+        String password = authentication.getCredentials().toString();
+        UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+        // TODO: additional rules beyond username/password with a custom UserDetails implementation
+        if(passwordEncoder.matches(password, userDetails.getPassword())) {
+            return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        } else {
+        throw new BadCredentialsException("Invalid credentials");
+        }
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return (UsernamePasswordAuthenticationToken.class.isAssignableFrom(authentication));
+    }
+}

--- a/backend/src/main/java/com/yurakim/readingtrace/shared/config/AuthenticationProviderImpl.java
+++ b/backend/src/main/java/com/yurakim/readingtrace/shared/config/AuthenticationProviderImpl.java
@@ -22,9 +22,11 @@ public class AuthenticationProviderImpl implements AuthenticationProvider {
     public Authentication authenticate(Authentication authentication) throws AuthenticationException {
         String username = authentication.getName();
         String password = authentication.getCredentials().toString();
+        //step3.provider checks user details with UserDetailsServiceImpl and PasswordEncoder(SecurityConfig)
         UserDetails userDetails = userDetailsService.loadUserByUsername(username);
         // TODO: additional rules beyond username/password with a custom UserDetails implementation
         if(passwordEncoder.matches(password, userDetails.getPassword())) {
+            //step4.provider returns authenticated object -> back to IAuthServiceImpl
             return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
         } else {
         throw new BadCredentialsException("Invalid credentials");

--- a/backend/src/main/java/com/yurakim/readingtrace/shared/config/SecurityConfig.java
+++ b/backend/src/main/java/com/yurakim/readingtrace/shared/config/SecurityConfig.java
@@ -3,7 +3,9 @@ package com.yurakim.readingtrace.shared.config;
 import com.yurakim.readingtrace.shared.constant.ApiPath;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -22,7 +24,6 @@ public class SecurityConfig {
                 .anyRequest().authenticated()
         );
 
-        http.formLogin(Customizer.withDefaults());
         http.httpBasic(Customizer.withDefaults());
 
         return http.build();
@@ -33,4 +34,8 @@ public class SecurityConfig {
         return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
 }

--- a/backend/src/main/java/com/yurakim/readingtrace/user/service/serviceImpl/IAuthServiceImpl.java
+++ b/backend/src/main/java/com/yurakim/readingtrace/user/service/serviceImpl/IAuthServiceImpl.java
@@ -8,6 +8,10 @@ import com.yurakim.readingtrace.user.repository.RoleRepository;
 import com.yurakim.readingtrace.user.repository.UserRepository;
 import com.yurakim.readingtrace.user.service.IAuthService;
 import lombok.AllArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -23,10 +27,19 @@ public class IAuthServiceImpl implements IAuthService {
     private final UserRepository userRepository;
     private final RoleRepository roleRepository;
     private final PasswordEncoder passwordEncoder;
+    private final AuthenticationManager authenticationManager;
 
     @Override
     public String login(LoginDto loginDto) {
-        userDetailsService.loadUserByUsername(loginDto.getEmail());
+        //step1.temporary request object for authentication
+        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                loginDto.getEmail(),
+                loginDto.getPassword()
+        );
+        //step2.manager delegates authentication to provider -> go to AuthenticationProviderImpl
+        Authentication authentication = authenticationManager.authenticate(authToken);
+        //step5.authentication object returned by AuthenticationProviderImpl saved in the SecurityContext
+        SecurityContextHolder.getContext().setAuthentication(authentication);
         return "Logged in";
     }
 

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -1,0 +1,64 @@
+server:
+  port: ${SERVER_PORT:8080}
+  error:
+    include-stacktrace: ${ERROR_STACKTRACE:never}
+    include-message: ${ERROR_MESSAGE:never}
+  shutdown: graceful
+
+spring:
+  application:
+    name: readingtrace
+  config:
+    activate:
+      on-profile: prod
+  output:
+    ansi:
+      enabled: ${ANSI_ENABLED:never}
+  datasource:
+    url: ${DATABASE_URL:jdbc:mysql://localhost:3306/readingtrace}
+    username: ${DB_USERNAME:root}
+    password: ${DB_PASSWORD:root}
+  jpa:
+    show-sql: ${JPA_SHOW_SQL:false}
+    hibernate:
+      ddl-auto: ${JPA_DDL_AUTO:validate}
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+        format_sql: ${JPA_FORMAT_SQL:false}
+
+#actuator
+management:
+  endpoints:
+    web:
+      exposure:
+        include: ${ACTUATOR_ENDPOINTS:health,metrics}
+      base-path: ${ACTUATOR_BASE_PATH:/actuator}
+  endpoint:
+    health:
+      show-details: ${ACTUATOR_HEALTH_DETAILS:never}
+    env:
+      show-values: ${ACTUATOR_SHOW_VALUES:never}
+    metrics:
+      enabled: ${ACTUATOR_METRICS:true}
+  security:
+    enabled: ${ACTUATOR_SECURITY:true}
+  metrics:
+    export:
+      prometheus:
+        enabled: ${PROMETHEUS_ENABLED:false}
+
+logging:
+  level:
+    root: ${ROOT_LOG_LEVEL:WARN}
+    org.springframework.security:  ${SECURITY_LOG_LEVEL:WARN}
+    org.hibernate.SQL: ${HIBERNATE_SQL_LOG:WARN}
+    org.hibernate.type.descriptor.sql.BasicBinder: ${HIBERNATE_PARAM_LOG:WARN}
+    com.yurakim.readingtrace: ${APP_LOG_LEVEL:INFO}
+  file:
+    name: ${LOG_FILE:logs/readingtrace.log}
+    max-size: ${LOG_MAX_SIZE:100MB}
+    max-history: ${LOG_MAX_HISTORY:30}
+  pattern:
+    file: ${LOG_PATTERN:%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n}
+    console: ${CONSOLE_LOG_PATTERN:%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -24,6 +24,13 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
         format_sql: ${JPA_FORMAT_SQL:true}
+        use_sql_comments: ${JPA_SQL_COMMENTS:true}
+        generate_statistics: ${JPA_STATISTICS:true}
+  devtools:
+    restart:
+      enabled: ${DEVTOOLS_RESTART:true}
+    livereload:
+      enabled: ${DEVTOOLS_LIVERELOAD:true}
 
 #actuator
 management:
@@ -41,11 +48,15 @@ management:
 
 logging:
   level:
+    root: ${ROOT_LOG_LEVEL:INFO}
     org.springframework.security:  ${SECURITY_LOG_LEVEL:TRACE}
     org.hibernate.SQL: ${HIBERNATE_SQL_LOG:DEBUG}
     org.hibernate.type.descriptor.sql.BasicBinder: ${HIBERNATE_PARAM_LOG:TRACE}
+    org.springframework.web: ${WEB_LOG_LEVEL:DEBUG}
+    org.springframework.transaction: ${TRANSACTION_LOG_LEVEL:DEBUG}
     com.yurakim.readingtrace: ${APP_LOG_LEVEL:DEBUG}
   file:
     name: ${LOG_FILE:}
   pattern:
-    file: ${LOG_PATTERN:%d{yyyy-MM-dd HH:mm:ss} - %msg%n}
+    console: ${CONSOLE_LOG_PATTERN:%clr(%d{HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}}
+    file: ${LOG_PATTERN:%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n}


### PR DESCRIPTION
**Description:**
Replace the default Spring Security login with a custom REST API login to better support JSON-based requests and responses

Default Spring Security login
- fixed URL `POST http://localhost:8080/login`
- request content type `x-www-form-urlencoded` (HTML form submission)
- fixed request parameter names `username`, `password`
- redirect response `302 redirect` for both success and failure

Custom REST API login flow
- JSON request/response
- Flexible endpoint URL `/api/v1/auth/login`